### PR TITLE
Add initial blog rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ layouts/         -> The ACTIVE templates that render the site:
   _default/      ->   Per-page templates (about, team, contact, ...), plus
                       list.html/taxonomy.html as generic fallbacks for any
                       section or tag/category page without a dedicated one.
+  blog/          ->   Blog list + single post templates.
   partials/      ->   Reusable partials + components/.
 ```
 
@@ -46,6 +47,14 @@ layouts/         -> The ACTIVE templates that render the site:
 
 - **Pages** live in `content/` as Markdown with YAML/TOML front matter.
   Create a new page with `hugo new content content/<name>.md`.
+- **Blog posts** live in `content/blog/` as Markdown. Create one with
+  `hugo new content blog/<slug>.md` — this scaffolds the front matter
+  (`title`, `date`, `summary`, `deck`, `hero_image`, `author`) from
+  [archetypes/blog.md](archetypes/blog.md). Set `draft: false` to publish.
+  The post body is regular Markdown. The listing at `/blog/` is generated
+  automatically (newest first, paginated) by
+  [layouts/blog/list.html](layouts/blog/list.html) and
+  [layouts/blog/single.html](layouts/blog/single.html).
 - **Team members** are defined in [data/team.yaml](data/team.yaml).
 - **Services** are defined in [data/services.yaml](data/services.yaml).
 - **Navigation and footer menus** are configured in the `[menu]` section of

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,0 +1,11 @@
+---
+title: "{{ replace .File.ContentBaseName "-" " " | title }}"
+date: {{ .Date }}
+draft: true
+summary: ""
+deck: ""
+hero_image: ""
+author: ""
+---
+
+Write your post here.

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Blog"
+hero_text: "Updates, insights, and stories from our work closing the digital divide."
+hero_image: "/images/backgrounds/about_team_cta.jpg"
+---

--- a/content/blog/welcome-to-the-t4eq-blog.md
+++ b/content/blog/welcome-to-the-t4eq-blog.md
@@ -5,7 +5,7 @@ draft: false
 summary: "A new vehicle to share all of our experiences and learnings with you!"
 deck: "A new place to follow our work, in our own words."
 author: "Javier Alvarez"
-hero_image: "/images/backgrounds/about_team_cta.jpg"
+hero_image: "/images/backgrounds/project_highlight.jpg"
 ---
 
 When T4EQ started, we were just a group of people with similar interests hoping to find a way to reduce 

--- a/content/blog/welcome-to-the-t4eq-blog.md
+++ b/content/blog/welcome-to-the-t4eq-blog.md
@@ -19,13 +19,13 @@ pages.
 ## What you can expect from this blog
 
 We expect to cover a wide range of topics, including:
-- **Our challenges**. The challenges we've faced (and continue to face) as an early-stage Swiss NGO, 
-  and how we're working through them.
+- **Our challenges**. The challenges we've faced (and continue to face) as an early-stage Swiss 
+  non-profit, and how we're working through them.
 - **Project updates**. As we move forward, we will keep you posted on our milestones, roadblocks, 
   and changes in direction. These updates keep us accountable and give everyone visibility into our 
   work and key learnings. 
 - **Engineering write-ups**. We favor simple, maintainable and sustainable solutions. You can expect 
-  deep-dives into bugs, design discussions, and technical trade-offs.
+  deep dives into bugs, design discussions, and technical trade-offs.
 - **Field notes**. What we've learned from working alongside community partners like AID India, the 
   impact our solutions are having, and how that feedback shapes our work and direction.
 - **Our financials**. As T4EQ grows, we will openly share our finances and operations so that you can 
@@ -33,9 +33,9 @@ We expect to cover a wide range of topics, including:
 
 ## Why we're doing this
 
-One of our core values is transparency. With this blog, we want to give you another viewpoint into 
+One of our core values is transparency. With this blog, we want to give you another window into 
 the work we do and encourage you to follow in our footsteps toward a more equal world, whether by 
-joining T4EQ, funding our work, partnering with us, or finding your own way to help closing the gap.
+joining T4EQ, funding our work, partnering with us, or finding your own way to help close the gap.
 
 We believe transparency is key to building trust and empowerment. By being open about our work (both 
 successes and failures) we give the community the tools to reuse what we've built and continue that 
@@ -46,5 +46,5 @@ cycle of empowerment.
 While we can't commit to a fixed schedule at this stage, we're aiming to post roughly once a month. 
 We're glad to have another way to share our work and what we're learning along the way.
 
-If you'd like to get involved, we would love to hear from you. Please, get in touch via our [contact 
+If you'd like to get involved, we would love to hear from you. Please get in touch via our [contact 
 form](/contact/).

--- a/content/blog/welcome-to-the-t4eq-blog.md
+++ b/content/blog/welcome-to-the-t4eq-blog.md
@@ -1,0 +1,56 @@
+---
+title: "Welcome to the T4EQ Blog"
+date: 2026-08-10
+draft: false
+summary: "A new vehicle to share all of our experiences and learnings with you!"
+deck: "A new place to follow our work, in our own words."
+author: "Javier Alvarez"
+hero_image: "/images/backgrounds/about_team_cta.jpg"
+---
+
+When T4EQ started, we were just a group of people with similar interests hoping to find a way to reduce 
+inequality in the world using our skills. Over the last year, we've learned a lot about topics that 
+were completely new to us. That's why we're excited to open a new communication channel to share our 
+work: the T4EQ blog! 
+
+The blog will contain supplementary material alongside our [projects](/projects/) and [about](/about/) 
+pages. We will deep-dive into all aspects of running T4EQ — the challenges, the successes, and the 
+failures — so that we can help others on a similar journey. 
+
+## What you can expect from this blog
+
+We expect to cover a wide range of topics, including:
+- **Project updates**. As we move forward with our projects, we will keep you posted on the milestones 
+  we hit, roadblocks, and changes in direction. These updates keep us accountable and give our partners 
+  visibility into our work — we're simply choosing to make that visibility public so everyone can learn 
+  from our experiences.
+- **Engineering write-ups**. We intend to not reinvent the wheel, favoring solutions that are simple, 
+  maintainable, and sustainable over clever ones. That approach often differs from what most engineers 
+  practice in their day-to-day work. You can expect deep-dives into bugs, design discussions, and 
+  technical trade-offs.
+- **Field notes**. What we've learned from working alongside community partners like AID India, the 
+  impact our solutions are having, and how that feedback shapes our work and direction.
+- **Our challenges**. The challenges we've faced — and continue to face — as an early-stage Swiss NGO, 
+  and how we're working through them.
+- **Our financials**. As T4EQ moves forward we might start receiving funding from third parties. 
+  We want to openly share how we finance ourselves and how we operate so that you can make an informed 
+  decision about whether this work is something you want to fund, and have the peace of mind knowing 
+  how your funding is used.
+
+## Why we're doing this
+
+One of our core values is transparency. With this blog, we want to give you another viewpoint into 
+the work we do and encourage you to follow in our footsteps toward a more equal world — whether by 
+joining T4EQ, funding our work, partnering with us, or finding your own way to help closing the gap.
+
+We believe transparency is key to building trust and empowerment. By being open about our work — 
+successes and failures alike — we give the community the tools to reuse what we've built and continue 
+that cycle of empowerment.
+
+## Stay tuned and follow along!
+
+While we can't commit to a fixed schedule at this stage, we're aiming to post roughly once a month. 
+We're glad to have another way to share our work and what we're learning along the way.
+
+If you'd like to get involved or have a challenge you think technology could help solve, 
+[get in touch](/contact/). We would love to hear from you.

--- a/content/blog/welcome-to-the-t4eq-blog.md
+++ b/content/blog/welcome-to-the-t4eq-blog.md
@@ -9,48 +9,42 @@ hero_image: "/images/backgrounds/project_highlight.jpg"
 ---
 
 When T4EQ started, we were just a group of people with similar interests hoping to find a way to reduce 
-inequality in the world using our skills. Over the last year, we've learned a lot about topics that 
-were completely new to us. That's why we're excited to open a new communication channel to share our 
-work: the T4EQ blog! 
+inequality in the world using technology and our skills. Over the last year, that has taken shape into 
+a concrete, evolving mission and we've learned a lot about topics that were completely new to us. 
+That's why we're excited to open a new communication channel to share our work: the T4EQ blog! 
 
 The blog will contain supplementary material alongside our [projects](/projects/) and [about](/about/) 
-pages. We will deep-dive into all aspects of running T4EQ — the challenges, the successes, and the 
-failures — so that we can help others on a similar journey. 
+pages.
 
 ## What you can expect from this blog
 
 We expect to cover a wide range of topics, including:
-- **Project updates**. As we move forward with our projects, we will keep you posted on the milestones 
-  we hit, roadblocks, and changes in direction. These updates keep us accountable and give our partners 
-  visibility into our work — we're simply choosing to make that visibility public so everyone can learn 
-  from our experiences.
-- **Engineering write-ups**. We intend to not reinvent the wheel, favoring solutions that are simple, 
-  maintainable, and sustainable over clever ones. That approach often differs from what most engineers 
-  practice in their day-to-day work. You can expect deep-dives into bugs, design discussions, and 
-  technical trade-offs.
+- **Our challenges**. The challenges we've faced (and continue to face) as an early-stage Swiss NGO, 
+  and how we're working through them.
+- **Project updates**. As we move forward, we will keep you posted on our milestones, roadblocks, 
+  and changes in direction. These updates keep us accountable and give everyone visibility into our 
+  work and key learnings. 
+- **Engineering write-ups**. We favor simple, maintainable and sustainable solutions. You can expect 
+  deep-dives into bugs, design discussions, and technical trade-offs.
 - **Field notes**. What we've learned from working alongside community partners like AID India, the 
   impact our solutions are having, and how that feedback shapes our work and direction.
-- **Our challenges**. The challenges we've faced — and continue to face — as an early-stage Swiss NGO, 
-  and how we're working through them.
-- **Our financials**. As T4EQ moves forward we might start receiving funding from third parties. 
-  We want to openly share how we finance ourselves and how we operate so that you can make an informed 
-  decision about whether this work is something you want to fund, and have the peace of mind knowing 
-  how your funding is used.
+- **Our financials**. As T4EQ grows, we will openly share our finances and operations so that you can 
+  make informed choices and know exactly how your support is used.
 
 ## Why we're doing this
 
 One of our core values is transparency. With this blog, we want to give you another viewpoint into 
-the work we do and encourage you to follow in our footsteps toward a more equal world — whether by 
+the work we do and encourage you to follow in our footsteps toward a more equal world, whether by 
 joining T4EQ, funding our work, partnering with us, or finding your own way to help closing the gap.
 
-We believe transparency is key to building trust and empowerment. By being open about our work — 
-successes and failures alike — we give the community the tools to reuse what we've built and continue 
-that cycle of empowerment.
+We believe transparency is key to building trust and empowerment. By being open about our work (both 
+successes and failures) we give the community the tools to reuse what we've built and continue that 
+cycle of empowerment.
 
 ## Stay tuned and follow along!
 
 While we can't commit to a fixed schedule at this stage, we're aiming to post roughly once a month. 
 We're glad to have another way to share our work and what we're learning along the way.
 
-If you'd like to get involved or have a challenge you think technology could help solve, 
-[get in touch](/contact/). We would love to hear from you.
+If you'd like to get involved, we would love to hear from you. Please, get in touch via our [contact 
+form](/contact/).

--- a/content/blog/welcome-to-the-t4eq-blog.md
+++ b/content/blog/welcome-to-the-t4eq-blog.md
@@ -24,7 +24,7 @@ We expect to cover a wide range of topics, including:
 - **Project updates**. As we move forward, we will keep you posted on our milestones, roadblocks, 
   and changes in direction. These updates keep us accountable and give everyone visibility into our 
   work and key learnings. 
-- **Engineering write-ups**. We favor simple, maintainable and sustainable solutions. You can expect 
+- **Engineering write-ups**. We favor simple, maintainable, and sustainable solutions. You can expect 
   deep dives into bugs, design discussions, and technical trade-offs.
 - **Field notes**. What we've learned from working alongside community partners like AID India, the 
   impact our solutions are having, and how that feedback shapes our work and direction.
@@ -38,7 +38,7 @@ the work we do and encourage you to follow in our footsteps toward a more equal 
 joining T4EQ, funding our work, partnering with us, or finding your own way to help close the gap.
 
 We believe transparency is key to building trust and empowerment. By being open about our work (both 
-successes and failures) we give the community the tools to reuse what we've built and continue that 
+successes and failures), we give the community the tools to reuse what we've built and continue that 
 cycle of empowerment.
 
 ## Stay tuned and follow along!

--- a/hugo.toml
+++ b/hugo.toml
@@ -24,17 +24,21 @@ title = "T4EQ — Tech for Equality"
     url = "/projects/"
     weight = 3
   [[menu.main]]
+    name = "Blog"
+    url = "/blog/"
+    weight = 4
+  [[menu.main]]
     name = "Team"
     url = "/team/"
-    weight = 4
+    weight = 5
   [[menu.main]]
     name = "Partners"
     url = "/partners/"
-    weight = 5
+    weight = 6
   [[menu.main]]
     name = "Contact"
     url = "/contact/"
-    weight = 6
+    weight = 7
 
   [[menu.footer]]
     name = "Tech for Equality"

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,18 @@
+{{ define "main" }}
+
+{{ partial "components/hero.html" (dict
+  "page" .
+  "image" .Params.hero_image
+  "title" (.Params.hero_title | default .Title)
+  "text" .Params.hero_text
+) }}
+
+{{ $paginator := .Paginate (.Pages.ByDate.Reverse) }}
+
+{{ partial "components/post-list.html" (dict
+  "background" "c-band--purple"
+  "posts" $paginator.Pages
+  "paginator" $paginator
+) }}
+
+{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,21 @@
+{{ define "main" }}
+
+{{ partial "components/hero.html" (dict
+  "page" .
+  "image" .Params.hero_image
+  "title" .Title
+  "text" .Params.deck
+) }}
+
+<section class="c-band c-band--purple c-band--posts">
+  <div class="container">
+    <p class="c-post__meta">
+      {{ if not .Date.IsZero }}<time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "January 2, 2006" }}</time>{{ end }}
+      {{ with .Params.author }} · {{ . }}{{ end }}
+    </p>
+    <div class="c-article">{{ .Content }}</div>
+    <p class="c-post__back">{{ partial "components/button.html" (dict "url" "/blog/" "label" "Back to Blog") }}</p>
+  </div>
+</section>
+
+{{ end }}

--- a/layouts/partials/components/post-list.html
+++ b/layouts/partials/components/post-list.html
@@ -1,0 +1,33 @@
+{{- /* Blog post list band. Params: background, title, level, intro,
+       posts (Pages), paginator (optional *Pager) */ -}}
+<section class="c-band c-band--posts {{ .background | default "c-band--purple" }}"{{ with .id }} id="{{ . }}"{{ end }}>
+  {{ partial "components/_band-header.html" (dict "title" .title "level" .level) }}
+  <div class="container">
+    {{ with .intro }}<p class="c-band__intro c-band__intro--wide c-band__intro--lead">{{ . }}</p>{{ end }}
+    {{ if .posts }}
+    <div class="c-post-grid">
+      {{ range .posts }}
+      <div class="c-post-card">
+        <div class="c-post-card__body">
+          {{ with .Date }}{{ if not .IsZero }}<time class="c-post-card__date" datetime="{{ .Format "2006-01-02" }}">{{ .Format "January 2, 2006" }}</time>{{ end }}{{ end }}
+          <h3 class="c-post-card__title">{{ .Title }}</h3>
+          <div class="c-post-card__excerpt">{{ .Summary }}</div>
+          {{ partial "components/button.html" (dict "url" .RelPermalink "label" "Read more") }}
+        </div>
+      </div>
+      {{ end }}
+    </div>
+    {{ with .paginator }}
+    {{ if gt .TotalPages 1 }}
+    <nav class="c-pager" aria-label="Blog pagination">
+      {{ if .HasPrev }}{{ partial "components/button.html" (dict "url" .Prev.URL "label" "Newer posts") }}{{ else }}<span></span>{{ end }}
+      <span class="c-pager__status">Page {{ .PageNumber }} of {{ .TotalPages }}</span>
+      {{ if .HasNext }}{{ partial "components/button.html" (dict "url" .Next.URL "label" "Older posts") }}{{ else }}<span></span>{{ end }}
+    </nav>
+    {{ end }}
+    {{ end }}
+    {{ else }}
+    <p class="c-band__intro c-band__intro--wide">No posts yet — check back soon.</p>
+    {{ end }}
+  </div>
+</section>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -927,8 +927,8 @@ main > .c-pageheader:first-child { padding-top: calc(var(--nav-height) + var(--s
 }
 .c-post-card__title {
   font-family: var(--font-mono);
-  font-size: var(--fs-h4);
-  font-weight: var(--fw-h4);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-h3);
   line-height: 1.2;
   letter-spacing: var(--ls-snug);
   margin-bottom: var(--space-md);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -335,6 +335,8 @@ body {
 .c-band { padding-bottom: var(--space-xl); }
 .c-band--people { padding-top: calc(var(--space-sm) + var(--space-sm)); padding-bottom: calc(var(--space-xl) + var(--space-lg)); }
 .c-band--people:has(.c-band__bar) { padding-top: 0; }
+.c-band--posts { padding-top: var(--space-lg); }
+.c-band--posts:has(.c-band__bar) { padding-top: 0; }
 .c-band--green .c-person__photo:not(:has(img)) { display: none; }
 .c-band--purple { background: var(--purple); color: var(--offwhite); }
 .c-band--green  { background: var(--green);  color: var(--offwhite); }
@@ -897,6 +899,138 @@ main > .c-pageheader:first-child { padding-top: calc(var(--nav-height) + var(--s
 .c-social__link { color: var(--offwhite); opacity: 1; transition: opacity 0.2s; }
 .c-social__link svg { width: 44px; height: 44px; }
 
+/* ── Blog: post grid + card ── */
+.c-post-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: var(--space-md);
+}
+.c-post-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line-soft);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+.c-post-card:hover { border-color: var(--line); }
+.c-post-card__body {
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.c-post-card__date {
+  font-family: var(--font-sans);
+  font-size: var(--fs-t3);
+  margin-bottom: var(--space-md);
+}
+.c-post-card__title {
+  font-family: var(--font-mono);
+  font-size: var(--fs-h4);
+  font-weight: var(--fw-h4);
+  line-height: 1.2;
+  letter-spacing: var(--ls-snug);
+  margin-bottom: var(--space-md);
+}
+.c-post-card__excerpt {
+  font-family: var(--font-sans);
+  font-size: var(--fs-t2);
+  font-weight: var(--fw-t2);
+  line-height: 1.5;
+  margin-bottom: var(--space-md);
+  flex: 1;
+}
+
+/* ── Blog: pagination ── */
+.c-pager {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: var(--space-md);
+  margin-top: var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: var(--fs-t3);
+  font-weight: var(--fs-t3);
+}
+.c-pager > :first-child { justify-self: start; }
+.c-pager__status { justify-self: center; }
+.c-pager > :last-child { justify-self: end; }
+
+/* ── Blog: article body (single post) ── */
+.c-post__meta {
+  max-width: 720px;
+  font-family: var(--font-sans);
+  font-size: var(--fs-t3);
+  margin-bottom: var(--space-md);
+}
+.c-article {
+  max-width: 720px;
+  font-family: var(--font-sans);
+  font-size: var(--fs-t2);
+  font-weight: var(--fw-t2);
+  line-height: 1.7;
+}
+.c-article > * + * { margin-top: var(--space-sm); }
+.c-article h1 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-h2);
+  font-weight: var(--fw-h2);
+  letter-spacing: var(--ls-tight);
+  margin-top: var(--space-lg);
+}
+.c-article h2 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-h3);
+  font-weight: var(--fw-h3);
+  line-height: 1.2;
+  letter-spacing: var(--ls-snug);
+  margin-top: var(--space-lg);
+}
+.c-article h3 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-h4);
+  font-weight: var(--fw-h4);
+  line-height: 1.2;
+  letter-spacing: var(--ls-snug);
+  margin-top: var(--space-md);
+}
+.c-article h4 {
+  font-family: var(--font-mono);
+  font-size: var(--fs-t2);
+  font-weight: var(--fw-t2);
+  line-height: 1.2;
+  letter-spacing: var(--ls-snug);
+  margin-top: var(--space-md);
+}
+.c-article ul, .c-article ol { padding-left: 1.25em; }
+.c-article li + li { margin-top: var(--space-xs); }
+.c-article a { text-decoration: underline; text-underline-offset: 3px; transition: opacity 0.2s; }
+.c-article a:hover { opacity: 0.7; }
+.c-article blockquote { border-left: 2px solid var(--line-soft); padding-left: var(--space-md); opacity: 0.9; }
+.c-article code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+  background: rgba(245, 245, 244, 0.12);
+  padding: 0.1em 0.4em;
+  border-radius: 4px;
+}
+.c-article pre {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: rgba(245, 245, 244, 0.12);
+  padding: var(--space-sm);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+.c-article pre code { background: none; padding: 0; }
+.c-article img { border-radius: var(--radius-sm); }
+.c-article hr { border: none; border-top: 1px solid var(--line-soft); margin: var(--space-lg) 0; }
+.c-post__back {
+  max-width: 720px;
+  margin-top: var(--space-lg);
+}
+
 /* ── Component responsive ── */
 @media (max-width: 900px) {
   .c-hero,
@@ -915,6 +1049,7 @@ main > .c-pageheader:first-child { padding-top: calc(var(--nav-height) + var(--s
   .c-process__steps { flex-direction: column; }
   .c-process__step { flex-basis: auto; padding: var(--space-md) var(--space-md); }
   .c-process__arrow { align-self: center; transform: rotate(90deg); }
+  .c-post-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 640px) {
@@ -926,4 +1061,6 @@ main > .c-pageheader:first-child { padding-top: calc(var(--nav-height) + var(--s
   .c-people-grid   { grid-template-columns: 1fr; max-width: 340px; margin-inline: auto; }
   .c-person        { max-width: none; }
   .c-person__photo { max-width: none; }
+  .c-pager         { grid-template-columns: 1fr; justify-items: start; gap: var(--space-sm); }
+  .c-pager__status { justify-self: start; }
 }


### PR DESCRIPTION
You can find a preview of this PR in https://t4eq.org/preview/blog-initialization/

This adds the layouts and templates for displaying a blog, so that we can just plainly add markdown files later to create a new blogpost, decoupling the look and feel from the content.

**TODO**: Find images for the blog page and for the posts under the blog page.