### PR TITLE
Add og:description to match hero text in each page.

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -15,6 +15,7 @@
 
   {{/* Open Graph */}}
   <meta property="og:title" content="{{ .Title }}">
+  <meta property="og:description" content="{{ .Params.hero_text | default .Params.deck | default .Params.tagline | default .Site.Params.description }}">
   <meta property="og:type" content="website">
   <meta property="og:url" content="{{ .Permalink }}">
   {{ with .Site.Params.ogImage }}<meta property="og:image" content="{{ . | absURL }}">{{ end }}


### PR DESCRIPTION
Uses the hero text (the subtitle of the page when there is an intro image in the page) and falls back to the site description if not available.

Before:
<img width="1228" height="1308" alt="image" src="https://github.com/user-attachments/assets/c5c7ecfe-bd25-4b01-ad36-9dbce72cbbe0" />

After: 
<img width="1228" height="1308" alt="image" src="https://github.com/user-attachments/assets/292bdefc-bb28-448f-a808-4f80fefe7398" />
