### PR TITLE
Proper comment section name

### DIFF
--- a/content/blog/first-challenge-blog.md
+++ b/content/blog/first-challenge-blog.md
@@ -2,7 +2,7 @@
 title: "Our first challenge"
 date: 2026-08-11
 draft: false
-summary: "Starting from a clean slate and zero connection to our first project!"
+summary: "Starting from a clean slate and zero connection to our first project."
 deck: "Starting from a clean slate and zero connection to our first project."
 hero_image: "/images/backgrounds/about_hero_v8.jpg"
 author: "Preethi Padmanabhan"

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -15,7 +15,11 @@
     </p>
     <div class="c-article">{{ .Content }}</div>
     <div class="c-comments">
-      <section id="isso-thread" data-title="Comments" data-isso-id="{{ (urls.Parse $.Permalink).Path }}"></section>
+      <section
+            id="isso-thread"
+            data-title="{{ if ne hugo.Environment "production" }}[preview] {{ end }}{{ $.Title }}"
+            data-isso-id="{{ (urls.Parse $.Permalink).Path }}">
+      </section>
     </div>
     {{ with .Site.Params.issoURL }}
     <script data-isso="{{ . }}" src="{{ . }}/js/embed.min.js" defer></script>


### PR DESCRIPTION
This is reported in moderation emails and in the [isso](https://isso-comments.de/) dashboard, let's make it have useful content.

With this change it will contain the title of the blog post, prefixed with `[preview]` if the comment was not posted on the production web, but in `https://t4eq.org/preview/<branch-name>/blog/<post>`.